### PR TITLE
Fix NoMethodError: undefined method `x_rate_reset` for #<Genderize::I…

### DIFF
--- a/lib/genderize/io/base.rb
+++ b/lib/genderize/io/base.rb
@@ -8,7 +8,7 @@ module Genderize
 
       DEFAULT_HOST = 'https://api.genderize.io'
       HEADER_KEYS = %w[
-        x_rate_limit_limit x_rate_limit_remaining x_rate_reset
+        x_rate_limit_limit x_rate_limit_remaining x_rate_limit_reset
       ].freeze
 
       attr_reader :country_id, :data, :host, :language_id, :name, :request


### PR DESCRIPTION
Fixes the following error:
```
NoMethodError: undefined method `x_rate_reset' for #<Genderize::Io::Parser::Header:0x000055578e1e3d78 @response="HTTP/1.1 200 OK\r\nServer: nginx/1.16.1\r\nDate: Mon, 26 Sep 2022 21:07:07 GMT\r\nContent-Type: application/json; charset=utf-8\r\nContent-Length: 83\r\nConnection: keep-alive\r\naccess-control-allow-credentials: true\r\naccess-control-allow-origin: *\r\naccess-control-expose-headers: x-rate-limit-limit,x-rate-limit-remaining,x-rate-limit-reset\r\ncache-control: max-age=0, private, must-revalidate\r\nx-rate-limit-limit: 1000\r\nx-rate-limit-remaining: 999\r\nx-rate-limit-reset: 10373\r\nx-request-id: FxiFHkfcOGeo4h8FIkjB\r\n\r\n", @strict=true, @headers=["HTTP/1.1 200 OK", "", "Server: nginx/1.16.1", "", "Date: Mon, 26 Sep 2022 21:07:07 GMT", "", "Content-Type: application/json; charset=utf-8", "", "Content-Length: 83", "", "Connection: keep-alive", "", "access-control-allow-credentials: true", "", "access-control-allow-origin: *", "", "access-control-expose-headers: x-rate-limit-limit,x-rate-limit-remaining,x-rate-limit-reset", "", "cache-control: max-age=0, private, must-revalidate", "", "x-rate-limit-limit: 1000", "", "x-rate-limit-remaining: 999", "", "x-rate-limit-reset: 10373", "", "x-request-id: FxiFHkfcOGeo4h8FIkjB"]>
  File "/app/vendor/bundle/ruby/3.0.0/gems/genderize-io-1.4.0/lib/genderize/io/parser/header.rb", line 27, in method_missing
  File "/app/vendor/bundle/ruby/3.0.0/gems/genderize-io-1.4.0/lib/genderize/io/base.rb", line 53, in block in generate_rate_limits
  File "/app/vendor/bundle/ruby/3.0.0/gems/genderize-io-1.4.0/lib/genderize/io/base.rb", line 53, in each
  File "/app/vendor/bundle/ruby/3.0.0/gems/genderize-io-1.4.0/lib/genderize/io/base.rb", line 53, in each_with_object
  File "/app/vendor/bundle/ruby/3.0.0/gems/genderize-io-1.4.0/lib/genderize/io/base.rb", line 53, in generate_rate_limits
  File "/app/vendor/bundle/ruby/3.0.0/gems/genderize-io-1.4.0/lib/genderize/io/lookup.rb", line 21, in determine
  File "/app/vendor/bundle/ruby/3.0.0/gems/genderize-io-1.4.0/lib/genderize/io/base.rb", line 26, in determine
```

The name of the header is `"x-rate-limit-reset"` not `"x-rate-reset"`